### PR TITLE
Use Path::Extended::Tiny

### DIFF
--- a/t/10_local.t
+++ b/t/10_local.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use FindBin;
-use Path::Extended;
+use Path::Extended::Tiny;
 use Test::More;
 use WorePAN;
 use Archive::Tar;


### PR DESCRIPTION
Path::Extended is not requirement of this package.

I got following error when testing.

```
% prove -bv t/10_local.t
t/10_local.t .. Can't locate Path/Extended.pm in @INC (you may need to install the Path::Extended module) (@INC contains: /home/syohei/.cpanm/work/1409738445.20480/WorePAN-0.12/blib/lib /home/syohei/.cpanm/work/1409738445.20480/WorePAN-0.12/blib/arch /home/syohei/.plenv/versions/5.20.0/lib/perl5/site_perl/5.20.0/x86_64-linux-thread-multi /home/syohei/.plenv/versions/5.20.0/lib/perl5/site_perl/5.20.0 /home/syohei/.plenv/versions/5.20.0/lib/perl5/5.20.0/x86_64-linux-thread-multi /home/syohei/.plenv/versions/5.20.0/lib/perl5/5.20.0 .) at t/10_local.t line 4.
BEGIN failed--compilation aborted at t/10_local.t line 4.
Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 

Test Summary Report
-------------------
t/10_local.t (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
Files=1, Tests=0,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.02 cusr  0.00 csys =  0.04 CPU)
Result: FAIL
```
